### PR TITLE
Update install.sh - move shebang to first line

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
 # Installation script to get Docker setup. Provide single
 # argument: driver type and os (Ubuntu or Centos supported)
 # in the following format docker/nvidia/ubuntu
-#!/bin/bash
+
 
 if [ $# -lt 1 ]
 	then


### PR DESCRIPTION
The shebang (#!/bin/bash) must be the very first line of a shell script in order to be interpreted as such by the Kernel. 
Having other comments above the shebang can result in errors such as below:

./install.sh: 51: ./install.sh: [[: not found