### PR TITLE
Regex support hash character

### DIFF
--- a/crackq/cq_api.py
+++ b/crackq/cq_api.py
@@ -95,7 +95,7 @@ class job_schema(Schema):
     job_id = fields.UUID(allow_none=None)
     task_id = fields.UUID(allow_none=None)
     hash_list = fields.List(fields.String(validate=StringContains(
-                            r'[^A-Za-z0-9\*\$\@\/\\\.\:\-\_\+\.\+\~]')),
+                            r'[^A-Za-z0-9\*\$\@\/\\\.\:\-\_\+\.\+\~\#]')),
                             allow_none=False, error_messages=error_messages)
     wordlist = fields.Str(allow_none=True, validate=[StringContains(r'[^A-Za-z0-9\_\-]'),
                                                      Length(min=1, max=60)])


### PR DESCRIPTION
Hash character is used by the hashformat Domain Cached Credentials 2 (DCC2), MS Cache 2. Trying to queue a job with a MS Cache 2 hash such as `$DCC2$10240#tom#e4e938d12fe5974dc42a90120bd9c90f` fails with a 500 error due to invalid hash_list format.

Extending the regex query makes the add function succeed.