### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/opencl/ubuntu/Dockerfile
+++ b/docker/opencl/ubuntu/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -q && apt-get install --no-install-recommends -yq alien wget 
 RUN export RUNTIME_URL="http://registrationcenter-download.intel.com/akdlm/irc_nas/9019/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz" \
     && export TAR=$(basename ${RUNTIME_URL}) \
     && export DIR=$(basename ${RUNTIME_URL} .tgz) \
-    && wget -q ${RUNTIME_URL} \
+    && wget --no-check-certificate -q ${RUNTIME_URL} \
     && tar -xf ${TAR} \
     && for i in ${DIR}/rpm/*.rpm; do alien --to-deb $i; done \
     && rm -rf ${DIR} ${TAR} \


### PR DESCRIPTION
Changes:

Added --no-check-certificate option to wget command: The wget command used to download the Intel OpenCL CPU runtime now includes the --no-check-certificate option. This change is made to avoid issues where wget fails due to problems with the server's SSL certificate.